### PR TITLE
Added ActiveProfiles in test classes and removed secret keys

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,14 +4,12 @@ keycloak.auth-server-url = https://auth.banyuwangikab.go.id
 keycloak.ssl-required = external
 keycloak.resource =banyuwangi-webapp
 keycloak.verify-token-audience=false
-keycloak.credentials.secret =fxraDjJMINZSunzgmom1GtrALENPN7sn
 keycloak.use-resource-role-mappings = false
 
 spring.security.oauth2.client.provider.banyuwangi.issuer-uri=https://auth.banyuwangikab.go.id/realms/banyuwangi
 
 spring.security.oauth2.client.provider.banyuwangi-test.issuer-uri=https://auth.banyuwangikab.go.id/realms/banyuwangi
 spring.security.oauth2.client.registration.banyuwangi-test.client-id=banyuwangi-test
-spring.security.oauth2.client.registration.banyuwangi-test.client-secret=MZASrIBdZrMSViBBgLhOCnOeatyiDYPD
 spring.security.oauth2.client.registration.banyuwangi-test.authorization-grant-type=client_credentials
 
 spring.rabbitmq.addresses=localhost:5672
@@ -73,7 +71,6 @@ dashboard.app.fcmRateLimit=4
 
 streaming.baseUrl=https://stream-ai.banyuwangikab.go.id
 streaming.server=https://stream-ai.banyuwangikab.go.id
-streaming.streamingToken=9f8c835e-1896-4f54-b544-29d2a6df802a
 
 gcp.firebase.serviceAccount=classpath:banyuwangi-dashboard-firebase-adminsdk.json
 

--- a/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/AlarmControllerTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/AlarmControllerTest.kt
@@ -9,11 +9,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class AlarmControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val alarmRepo: AlarmRepo,

--- a/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/CameraControllerTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/CameraControllerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -18,6 +19,7 @@ import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class CameraControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val tokenManager: TokenManager,

--- a/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/ChartControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/ChartControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -20,6 +21,7 @@ import java.net.InetSocketAddress
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class ChartControllerIntegrationTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val tokenManager: TokenManager,

--- a/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/DetectionControllerTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/DetectionControllerTest.kt
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.Sort.Direction
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -35,6 +36,7 @@ import java.util.UUID
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class DetectionControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val tokenManager: TokenManager,

--- a/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/FirebaseControllerTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/FirebaseControllerTest.kt
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.put
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class FirebaseControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val tokenManager: TokenManager,

--- a/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/LiveViewControllerTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/banyuwangi/controller/LiveViewControllerTest.kt
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -26,6 +27,7 @@ import java.util.UUID
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class LiveViewControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val tokenManager: TokenManager,

--- a/src/test/kotlin/com/katalisindonesia/imageserver/controller/ImageControllerTest.kt
+++ b/src/test/kotlin/com/katalisindonesia/imageserver/controller/ImageControllerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -30,6 +31,7 @@ import java.util.UUID
     classes = [BanyuwangiCoreApplication::class]
 )
 @AutoConfigureMockMvc
+@ActiveProfiles("secret", "default")
 class ImageControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val imageProperties: ImageProperties,


### PR DESCRIPTION
The ActiveProfiles were added to specify which profiles are active when running the tests in the 'DetectionControllerTest', 'ChartControllerIntegrationTest', 'CameraControllerTest', 'ImageControllerTest', 'LiveViewControllerTest', 'AlarmControllerTest', and 'FirebaseControllerTest' Kotlin test classes. This will allow testing under various application configurations. This change is necessary for creating an environment specific to testing.

Additionally, the 'keycloak.credentials.secret' and 'spring.security.oauth2.client.registration.banyuwangi-test.client-secret' keys were removed from the application.properties file to improve security by avoiding the exposure of secret keys. Also, the 'streaming.streamingToken' had been deleted because it is not required anymore in this configuration."